### PR TITLE
Changed output from python list to List.

### DIFF
--- a/Nodes/Borrow Element.dyf
+++ b/Nodes/Borrow Element.dyf
@@ -27,6 +27,7 @@ ids = [elem.Id for elem in elements]
 IDS = List[ElementId](ids)
 
 try: checkedout_elem = [doc.GetElement(checkedout_el) for checkedout_el in WorksharingUtils.CheckoutElements(doc,IDS)]
+	checkedout_elem = List[Element](checkedout_elem)
 except Exception,er: checkedout_elem.append(str(er))
 
 OUT = checkedout_elem</Script>


### PR DESCRIPTION
Previously, this node used to output a python list of elements. Native nodes can't use those. Therefore, in order to be able to only continue work on the elements that are borrowed, I've converted the output to a C# List that other nodes can use.